### PR TITLE
Add local Ollama pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,35 @@ The `/deploy/helm/` directory contains a `nvidia-blueprint-vss-2.3.0.tgz` file w
 - NVIDIA GPU Operator v23.9 (Recommended minimum version)
 - Helm v3.x
 
+### Local Setup with Ollama + Whisper
+
+1. Install Whisper:
+   ```bash
+   pip install -U openai-whisper
+   ```
+
+2. Install and start Ollama:
+   ```bash
+   curl -fsSL https://ollama.com/install.sh | sh
+   ollama serve &
+   ```
+
+   Or use Docker Compose:
+   ```bash
+   docker-compose up -d
+   ```
+
+3. Pull models:
+   ```bash
+   ollama pull llava-llama3:instruct
+   ollama pull dengcao/Qwen3-Reranker-0.6B
+   ```
+
+4. Run the pipeline:
+   ```bash
+   python src/vss_engine/pipeline.py
+   ```
+   This uses Whisper for ASR, LLaVA for image captioning, and Qwen for reranking.
 ## Known CVEs
 
 VSS Engine 2.3.0 Container has the following known CVEs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    command: serve
+
+volumes:
+  ollama_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+torch
+whisper

--- a/src/vss_engine/pipeline.py
+++ b/src/vss_engine/pipeline.py
@@ -1,0 +1,54 @@
+import requests
+import whisper
+
+
+class LocalPipeline:
+    """Simple pipeline using local models via Ollama and Whisper."""
+
+    def __init__(self, ollama_url: str = "http://localhost:11434") -> None:
+        self.ollama_url = ollama_url.rstrip("/")
+        self.asr_model = whisper.load_model("small")
+
+    def transcribe(self, audio_path: str) -> str:
+        result = self.asr_model.transcribe(audio_path)
+        return result.get("text", "")
+
+    def caption(self, image_path: str) -> str:
+        with open(image_path, "rb") as img:
+            resp = requests.post(
+                f"{self.ollama_url}/api/generate",
+                json={
+                    "model": "llava-llama3:instruct",
+                    "prompt": "Describe this image.",
+                    "images": [image_path],
+                },
+            )
+        resp.raise_for_status()
+        return resp.json().get("response", "")
+
+    def rerank(self, query: str, docs: list[str]):
+        results = []
+        for doc in docs:
+            prompt = f"Query: {query}\nDocument: {doc}\nScore 0-1:"
+            resp = requests.post(
+                f"{self.ollama_url}/api/generate",
+                json={"model": "dengcao/Qwen3-Reranker-0.6B", "prompt": prompt},
+            )
+            resp.raise_for_status()
+            score = float(resp.json().get("response", "0").strip())
+            results.append((doc, score))
+        return sorted(results, key=lambda x: x[1], reverse=True)
+
+
+if __name__ == "__main__":
+    pipe = LocalPipeline()
+    # Example usage; replace with your own paths and documents
+    transcript = pipe.transcribe("audio.wav")
+    print("Transcript:", transcript)
+
+    caption = pipe.caption("frame.jpg")
+    print("Caption:", caption)
+
+    docs = ["doc one", "another document"]
+    ranked = pipe.rerank("example query", docs)
+    print("Reranked docs:", ranked)


### PR DESCRIPTION
## Summary
- add requirements with torch, whisper and requests
- add simple local pipeline using Ollama and Whisper
- add optional docker-compose for running Ollama
- document local setup in README

## Testing
- `python -m py_compile src/vss_engine/pipeline.py`
- `docker-compose -f docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669e693d8c832a9c77a0e9f15738b1