### PR TITLE
Add local Ollama pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,41 @@ The `/deploy/helm/` directory contains a `nvidia-blueprint-vss-2.3.0.tgz` file w
 - NVIDIA GPU Operator v23.9 (Recommended minimum version)
 - Helm v3.x
 
+### Local Setup with Ollama + Whisper
+
+1. Install Whisper from source for compatibility with the latest PyTorch:
+   ```bash
+   pip install git+https://github.com/openai/whisper.git
+   ```
+
+2. Install and start Ollama:
+   ```bash
+   curl -fsSL https://ollama.com/install.sh | sh
+   ollama serve &
+   ```
+
+   Or use Docker Compose:
+   ```bash
+   docker-compose up -d
+   ```
+
+   Or run the helper script:
+   ```bash
+   ./run_local.sh
+   ```
+   This helper installs Whisper from source, starts Ollama on port 51234, pulls models, and runs the pipeline.
+
+3. Pull models:
+   ```bash
+   ollama pull llava-llama3:instruct
+   ollama pull dengcao/Qwen3-Reranker-0.6B
+   ```
+
+4. Run the pipeline:
+   ```bash
+   python src/vss_engine/pipeline.py
+   ```
+   This uses Whisper for ASR, LLaVA for image captioning, and Qwen for reranking.
 ## Known CVEs
 
 VSS Engine 2.3.0 Container has the following known CVEs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    command: serve
+
+volumes:
+  ollama_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+torch
+git+https://github.com/openai/whisper.git

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Simple helper to run Ollama and the pipeline on an uncommon port.
+set -euo pipefail
+
+PORT=51234
+# Ensure whisper is installed from source
+pip install -q git+https://github.com/openai/whisper.git
+
+
+# Start Ollama on the chosen port in the background
+if ! command -v ollama >/dev/null 2>&1; then
+  echo "Ollama is not installed. Please install it first." >&2
+  exit 1
+fi
+
+# run ollama serve on specified port using environment variable
+export OLLAMA_HOST="localhost:${PORT}"
+ollama serve > ollama.log 2>&1 &
+OLLAMA_PID=$!
+
+# Wait for server
+until curl -sf "http://localhost:${PORT}/api/tags" >/dev/null; do
+  sleep 1
+done
+
+echo "Ollama running on port ${PORT}"
+
+# Pull required models
+ollama pull llava-llama3:instruct
+ollama pull dengcao/Qwen3-Reranker-0.6B
+
+# Run the Python pipeline using the same port
+python src/vss_engine/pipeline.py --ollama-url "http://localhost:${PORT}"
+
+# Stop Ollama
+kill $OLLAMA_PID

--- a/src/vss_engine/pipeline.py
+++ b/src/vss_engine/pipeline.py
@@ -1,0 +1,61 @@
+import requests
+import whisper
+
+
+class LocalPipeline:
+    """Simple pipeline using local models via Ollama and Whisper."""
+
+    def __init__(self, ollama_url: str = "http://localhost:11434") -> None:
+        self.ollama_url = ollama_url.rstrip("/")
+        self.asr_model = whisper.load_model("small")
+
+    def transcribe(self, audio_path: str) -> str:
+        result = self.asr_model.transcribe(audio_path)
+        return result.get("text", "")
+
+    def caption(self, image_path: str) -> str:
+        with open(image_path, "rb") as img:
+            resp = requests.post(
+                f"{self.ollama_url}/api/generate",
+                json={
+                    "model": "llava-llama3:instruct",
+                    "prompt": "Describe this image.",
+                    "images": [image_path],
+                },
+            )
+        resp.raise_for_status()
+        return resp.json().get("response", "")
+
+    def rerank(self, query: str, docs: list[str]):
+        results = []
+        for doc in docs:
+            prompt = f"Query: {query}\nDocument: {doc}\nScore 0-1:"
+            resp = requests.post(
+                f"{self.ollama_url}/api/generate",
+                json={"model": "dengcao/Qwen3-Reranker-0.6B", "prompt": prompt},
+            )
+            resp.raise_for_status()
+            score = float(resp.json().get("response", "0").strip())
+            results.append((doc, score))
+        return sorted(results, key=lambda x: x[1], reverse=True)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run local VSS pipeline")
+    parser.add_argument("--ollama-url", default="http://localhost:11434", help="Base URL for Ollama server")
+    parser.add_argument("--audio", default="audio.wav", help="Path to audio file")
+    parser.add_argument("--image", default="frame.jpg", help="Path to image file")
+    args = parser.parse_args()
+
+    pipe = LocalPipeline(args.ollama_url)
+    transcript = pipe.transcribe(args.audio)
+    print("Transcript:", transcript)
+
+    caption = pipe.caption(args.image)
+    print("Caption:", caption)
+
+    docs = ["doc one", "another document"]
+    ranked = pipe.rerank("example query", docs)
+    print("Reranked docs:", ranked)


### PR DESCRIPTION
## Summary
- add requirements with torch, whisper and requests
- add simple local pipeline using Ollama and Whisper
- add optional docker-compose for running Ollama
- document local setup in README
- add helper script to run Ollama on port 51234 and pass port via CLI
- fix whisper package name
- install Whisper from GitHub for newer PyTorch

## Testing
- `python -m py_compile src/vss_engine/pipeline.py`
- `bash -n run_local.sh`
- `docker-compose -f docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669e693d8c832a9c77a0e9f15738b1