### PR TITLE
Add local Gradio pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,43 @@ The `/deploy/helm/` directory contains a `nvidia-blueprint-vss-2.3.0.tgz` file w
 - NVIDIA GPU Operator v23.9 (Recommended minimum version)
 - Helm v3.x
 
+### Local Setup with Ollama + Whisper
+
+1. Install PyTorch with CUDA 12.8 support and Whisper from source:
+   ```bash
+   pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
+   pip3 install git+https://github.com/openai/whisper.git
+   ```
+
+2. Install and start Ollama:
+   ```bash
+   curl -fsSL https://ollama.com/install.sh | sh
+   ollama serve &
+   ```
+
+   Or use Docker Compose:
+   ```bash
+   docker-compose up -d
+   ```
+
+   Or run the helper script:
+   ```bash
+  ./run_local.sh
+  ```
+  This helper installs the required PyTorch build and Whisper, starts Ollama on port 51234, pulls models, and launches the Gradio interface.
+
+3. Pull models:
+   ```bash
+   ollama pull llava-llama3:8b
+   ollama pull dengcao/Qwen3-Reranker-8B:Q5_K_M
+   ```
+
+4. Launch the Gradio interface (or use `run_local.sh`):
+   ```bash
+   python src/vss_engine/gradio_frontend.py
+   ```
+   This uses Whisper for ASR, LLaVA for image captioning, and Qwen for reranking.
+   When the model response includes a timestamp, click it to jump to that time in the video.
 ## Known CVEs
 
 VSS Engine 2.3.0 Container has the following known CVEs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    command: serve
+
+volumes:
+  ollama_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+requests
+torch
+torchvision
+torchaudio
+git+https://github.com/openai/whisper.git
+gradio
+moviepy

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Simple helper to run Ollama and the pipeline on an uncommon port.
+set -euo pipefail
+
+PORT=51234
+# Install PyTorch for GPUs using CUDA 12.8 and Whisper from source
+pip3 install -q torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
+pip3 install -q git+https://github.com/openai/whisper.git
+
+
+# Start Ollama on the chosen port in the background
+if ! command -v ollama >/dev/null 2>&1; then
+  echo "Ollama is not installed. Please install it first." >&2
+  exit 1
+fi
+
+# run ollama serve on specified port using environment variable
+export OLLAMA_HOST="localhost:${PORT}"
+ollama serve > ollama.log 2>&1 &
+OLLAMA_PID=$!
+
+# Wait for server
+until curl -sf "http://localhost:${PORT}/api/tags" >/dev/null; do
+  sleep 1
+done
+
+echo "Ollama running on port ${PORT}"
+
+# Pull required models
+ollama pull llava-llama3:8b
+ollama pull dengcao/Qwen3-Reranker-8B:Q5_K_M
+
+# Launch the Gradio frontend using the same port
+python src/vss_engine/gradio_frontend.py --ollama-url "http://localhost:${PORT}"
+
+# Stop Ollama
+kill $OLLAMA_PID

--- a/src/vss_engine/gradio_frontend.py
+++ b/src/vss_engine/gradio_frontend.py
@@ -1,0 +1,103 @@
+import argparse
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import gradio as gr
+
+# Allow importing pipeline when executed from repository root
+sys_path = Path(__file__).resolve().parent
+import sys
+sys.path.append(str(sys_path))
+from pipeline import LocalPipeline
+
+
+def extract_media(video_path: str):
+    """Extract audio and a representative frame using ffmpeg."""
+    tmpdir = tempfile.mkdtemp()
+    audio_path = os.path.join(tmpdir, "audio.wav")
+    frame_path = os.path.join(tmpdir, "frame.jpg")
+
+    subprocess.run([
+        "ffmpeg",
+        "-i",
+        video_path,
+        "-vn",
+        "-acodec",
+        "pcm_s16le",
+        "-ar",
+        "16000",
+        "-ac",
+        "1",
+        audio_path,
+    ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    subprocess.run([
+        "ffmpeg",
+        "-i",
+        video_path,
+        "-vf",
+        "select=eq(n\\,0)",
+        "-vframes",
+        "1",
+        frame_path,
+    ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    return audio_path, frame_path, tmpdir
+
+
+class GradioApp:
+    def __init__(self, ollama_url: str):
+        self.pipeline = LocalPipeline(ollama_url)
+        self.transcript = ""
+
+    def process_upload(self, video_file):
+        if video_file is None:
+            return "", ""
+        audio, frame, tmp = extract_media(video_file)
+        self.transcript = self.pipeline.transcribe(audio)
+        caption = self.pipeline.caption(frame)
+        # cleanup tmpdir later
+        return self.transcript, caption
+
+    def answer(self, question, history):
+        if not self.transcript:
+            return history + [[question, "Upload a video first."],]
+        response = self.pipeline.answer(question, self.transcript)
+        ts_match = re.search(r"(\d{1,2}:\d{2})", response)
+        if ts_match:
+            mmss = ts_match.group(1)
+            m, s = map(int, mmss.split(":"))
+            sec = m * 60 + s
+            link = f'<a href="#" onclick="document.getElementById(\'video\').currentTime={sec}; return false;">{mmss}</a>'
+            response = response.replace(mmss, link)
+        history.append([question, response])
+        return history
+
+    def launch(self):
+        with gr.Blocks() as demo:
+            state = gr.State([])
+            video = gr.Video(label="Video", elem_id="video")
+            transcript_box = gr.Textbox(label="Transcript")
+            caption_box = gr.Textbox(label="Caption")
+            chatbot = gr.Chatbot()
+            question = gr.Textbox(label="Question")
+            send = gr.Button("Ask")
+
+            video.upload(self.process_upload, inputs=video, outputs=[transcript_box, caption_box])
+            send.click(self.answer, inputs=[question, chatbot], outputs=chatbot)
+        demo.launch()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ollama-url", default="http://localhost:11434")
+    args = parser.parse_args()
+    app = GradioApp(args.ollama_url)
+    app.launch()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vss_engine/pipeline.py
+++ b/src/vss_engine/pipeline.py
@@ -1,0 +1,74 @@
+import requests
+import whisper
+
+
+class LocalPipeline:
+    """Simple pipeline using local models via Ollama and Whisper."""
+
+    def __init__(self, ollama_url: str = "http://localhost:11434") -> None:
+        self.ollama_url = ollama_url.rstrip("/")
+        self.asr_model = whisper.load_model("small")
+
+    def transcribe(self, audio_path: str) -> str:
+        result = self.asr_model.transcribe(audio_path)
+        return result.get("text", "")
+
+    def caption(self, image_path: str) -> str:
+        with open(image_path, "rb") as img:
+            resp = requests.post(
+                f"{self.ollama_url}/api/generate",
+                json={
+                    "model": "llava-llama3:8b",
+                    "prompt": "Describe this image.",
+                    "images": [image_path],
+                },
+            )
+        resp.raise_for_status()
+        return resp.json().get("response", "")
+
+    def rerank(self, query: str, docs: list[str]):
+        results = []
+        for doc in docs:
+            prompt = f"Query: {query}\nDocument: {doc}\nScore 0-1:"
+            resp = requests.post(
+                f"{self.ollama_url}/api/generate",
+                json={"model": "dengcao/Qwen3-Reranker-8B:Q5_K_M", "prompt": prompt},
+            )
+            resp.raise_for_status()
+            score = float(resp.json().get("response", "0").strip())
+            results.append((doc, score))
+        return sorted(results, key=lambda x: x[1], reverse=True)
+
+    def answer(self, question: str, transcript: str) -> str:
+        """Generate an answer from the video transcript."""
+        prompt = (
+            f"Video transcript:\n{transcript}\n\nQuestion: {question}\n"
+            "Answer the question and include the timestamp in mm:ss if relevant."
+        )
+        resp = requests.post(
+            f"{self.ollama_url}/api/generate",
+            json={"model": "llava-llama3:8b", "prompt": prompt},
+        )
+        resp.raise_for_status()
+        return resp.json().get("response", "")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run local VSS pipeline")
+    parser.add_argument("--ollama-url", default="http://localhost:11434", help="Base URL for Ollama server")
+    parser.add_argument("--audio", default="audio.wav", help="Path to audio file")
+    parser.add_argument("--image", default="frame.jpg", help="Path to image file")
+    args = parser.parse_args()
+
+    pipe = LocalPipeline(args.ollama_url)
+    transcript = pipe.transcribe(args.audio)
+    print("Transcript:", transcript)
+
+    caption = pipe.caption(args.image)
+    print("Caption:", caption)
+
+    docs = ["doc one", "another document"]
+    ranked = pipe.rerank("example query", docs)
+    print("Reranked docs:", ranked)


### PR DESCRIPTION
## Summary
- run Ollama and launch Gradio UI from helper script
- extract audio and image with ffmpeg when video uploaded
- link timestamps in answers to seek video playback

## Testing
- `python -m py_compile src/vss_engine/pipeline.py`
- `python -m py_compile src/vss_engine/gradio_frontend.py`
- `bash -n run_local.sh`
- `docker-compose -f docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669e693d8c832a9c77a0e9f15738b1