### PR TITLE
Improve ffmpeg error message and update Gradio chatbot

### DIFF
--- a/src/vss_engine/pipeline.py
+++ b/src/vss_engine/pipeline.py
@@ -1,5 +1,6 @@
 import requests
 import whisper
+import base64
 
 
 class LocalPipeline:
@@ -14,17 +15,18 @@ class LocalPipeline:
         return result.get("text", "")
 
     def caption(self, image_path: str) -> str:
+        """Generate an image caption using the local VLM."""
         with open(image_path, "rb") as img:
-            resp = requests.post(
-                f"{self.ollama_url}/api/generate",
-                json={
+            img_b64 = base64.b64encode(img.read()).decode()
 
-                    "model": "llava-llama3:8b",
-
-                    "prompt": "Describe this image.",
-                    "images": [image_path],
-                },
-            )
+        resp = requests.post(
+            f"{self.ollama_url}/api/generate",
+            json={
+                "model": "llava-llama3:8b",
+                "prompt": "Describe this image.",
+                "images": [img_b64],
+            },
+        )
         resp.raise_for_status()
         return resp.json().get("response", "")
 


### PR DESCRIPTION
## Summary
- capture FFmpeg stderr so any errors surface in logs
- use `type="messages"` when constructing the Gradio `Chatbot`
- encode images as base64 when calling Ollama's caption endpoint

## Testing
- `python -m py_compile src/vss_engine/gradio_frontend.py src/vss_engine/pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6866e389ab80832aa5043f3e595518e6