### PR TITLE
Fix chatbot messages and process all frames

### DIFF
--- a/src/vss_engine/gradio_frontend.py
+++ b/src/vss_engine/gradio_frontend.py
@@ -13,13 +13,13 @@ import gradio as gr
 # Allow importing pipeline when executed from repository root
 sys_path = Path(__file__).resolve().parent
 import sys
+
 sys.path.append(str(sys_path))
 from pipeline import LocalPipeline
 
 
-
 def extract_media(video_path: str | os.PathLike):
-    """Extract audio and a representative frame using ffmpeg."""
+    """Extract audio and all frames using ffmpeg."""
     if not shutil.which("ffmpeg"):
         raise RuntimeError("ffmpeg is required but not installed")
 
@@ -27,8 +27,8 @@ def extract_media(video_path: str | os.PathLike):
 
     tmpdir = tempfile.mkdtemp()
     audio_path = os.path.join(tmpdir, "audio.wav")
-    frame_path = os.path.join(tmpdir, "frame.jpg")
-
+    frames_dir = os.path.join(tmpdir, "frames")
+    os.makedirs(frames_dir, exist_ok=True)
 
     try:
         subprocess.run(
@@ -46,8 +46,9 @@ def extract_media(video_path: str | os.PathLike):
                 audio_path,
             ],
             check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
         )
 
         subprocess.run(
@@ -55,41 +56,46 @@ def extract_media(video_path: str | os.PathLike):
                 "ffmpeg",
                 "-i",
                 video_path,
-                "-vf",
-                "select=eq(n\\,0)",
-                "-vframes",
-                "1",
-                frame_path,
+                os.path.join(frames_dir, "frame_%05d.jpg"),
             ],
             check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
         )
     except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"ffmpeg failed: {e}") from e
+        msg = e.stderr.strip() if e.stderr else str(e)
+        raise RuntimeError(f"ffmpeg failed: {msg}") from e
 
-
-    return audio_path, frame_path, tmpdir
+    frame_paths = sorted(
+        str(p) for p in Path(frames_dir).glob("frame_*.jpg")
+    )
+    return audio_path, frame_paths, tmpdir
 
 
 class GradioApp:
     def __init__(self, ollama_url: str):
         self.pipeline = LocalPipeline(ollama_url)
         self.transcript = ""
+        self.frames: list[str] = []
+        self.captions: list[str] = []
 
     def process_upload(self, video_file):
         if video_file is None:
             return "", ""
-        audio, frame, tmp = extract_media(video_file)
+        audio, self.frames, tmp = extract_media(video_file)
         self.transcript = self.pipeline.transcribe(audio)
-        caption = self.pipeline.caption(frame)
+        self.captions = [self.pipeline.caption(f) for f in self.frames]
+        caption = self.captions[0] if self.captions else ""
         # cleanup tmpdir later
         return self.transcript, caption
 
     def answer(self, question, history):
         if not self.transcript:
-            return history + [[question, "Upload a video first."],]
-        response = self.pipeline.answer(question, self.transcript)
+            history.append({"role": "user", "content": question})
+            history.append({"role": "assistant", "content": "Upload a video first."})
+            return history
+        response = self.pipeline.answer(question, self.transcript, self.captions)
         ts_match = re.search(r"(\d{1,2}:\d{2})", response)
         if ts_match:
             mmss = ts_match.group(1)
@@ -97,7 +103,8 @@ class GradioApp:
             sec = m * 60 + s
             link = f'<a href="#" onclick="document.getElementById(\'video\').currentTime={sec}; return false;">{mmss}</a>'
             response = response.replace(mmss, link)
-        history.append([question, response])
+        history.append({"role": "user", "content": question})
+        history.append({"role": "assistant", "content": response})
         return history
 
     def launch(self):
@@ -106,7 +113,7 @@ class GradioApp:
             video = gr.Video(label="Video", elem_id="video")
             transcript_box = gr.Textbox(label="Transcript")
             caption_box = gr.Textbox(label="Caption")
-            chatbot = gr.Chatbot()
+            chatbot = gr.Chatbot(type="messages")
             question = gr.Textbox(label="Question")
             send = gr.Button("Ask")
 

--- a/src/vss_engine/pipeline.py
+++ b/src/vss_engine/pipeline.py
@@ -1,5 +1,6 @@
 import requests
 import whisper
+import base64
 
 
 class LocalPipeline:
@@ -14,17 +15,19 @@ class LocalPipeline:
         return result.get("text", "")
 
     def caption(self, image_path: str) -> str:
+        """Generate an image caption using the local VLM."""
         with open(image_path, "rb") as img:
-            resp = requests.post(
-                f"{self.ollama_url}/api/generate",
-                json={
+            img_b64 = base64.b64encode(img.read()).decode()
 
-                    "model": "llava-llama3:8b",
-
-                    "prompt": "Describe this image.",
-                    "images": [image_path],
-                },
-            )
+        resp = requests.post(
+            f"{self.ollama_url}/api/generate",
+            json={
+                "model": "llava-llama3:8b",
+                "prompt": "Describe this image.",
+                "images": [img_b64],
+                "stream": False,
+            },
+        )
         resp.raise_for_status()
         return resp.json().get("response", "")
 
@@ -34,9 +37,11 @@ class LocalPipeline:
             prompt = f"Query: {query}\nDocument: {doc}\nScore 0-1:"
             resp = requests.post(
                 f"{self.ollama_url}/api/generate",
-
-                json={"model": "dengcao/Qwen3-Reranker-8B:Q5_K_M", "prompt": prompt},
-
+                json={
+                    "model": "dengcao/Qwen3-Reranker-8B:Q5_K_M",
+                    "prompt": prompt,
+                    "stream": False,
+                },
             )
             resp.raise_for_status()
             score = float(resp.json().get("response", "0").strip())
@@ -44,15 +49,24 @@ class LocalPipeline:
         return sorted(results, key=lambda x: x[1], reverse=True)
 
 
-    def answer(self, question: str, transcript: str) -> str:
-        """Generate an answer from the video transcript."""
+    def answer(
+        self, question: str, transcript: str, captions: list[str] | None = None
+    ) -> str:
+        """Generate an answer using the transcript and frame captions."""
+        caption_text = "\n".join(captions or [])
         prompt = (
-            f"Video transcript:\n{transcript}\n\nQuestion: {question}\n"
+            f"Video transcript:\n{transcript}\n"
+            f"Frame captions:\n{caption_text}\n\n"
+            f"Question: {question}\n"
             "Answer the question and include the timestamp in mm:ss if relevant."
         )
         resp = requests.post(
             f"{self.ollama_url}/api/generate",
-            json={"model": "llava-llama3:8b", "prompt": prompt},
+            json={
+                "model": "llava-llama3:8b",
+                "prompt": prompt,
+                "stream": False,
+            },
         )
         resp.raise_for_status()
         return resp.json().get("response", "")


### PR DESCRIPTION
## Summary
- extract audio and every frame using ffmpeg
- caption all frames and store results
- fix Gradio chatbot to use messages format
- include frame captions when answering questions

## Testing
- `python -m py_compile src/vss_engine/gradio_frontend.py src/vss_engine/pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6866e389ab80832aa5043f3e595518e6