### PR TITLE
Expose gradio app publicly

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ The `/deploy/helm/` directory contains a `nvidia-blueprint-vss-2.3.0.tgz` file w
    ```bash
    python src/vss_engine/gradio_frontend.py
    ```
+   The interface now binds to `0.0.0.0` so it can be reached from other machines.
+   Use `--share` to obtain a public Gradio link.
    This uses Whisper for ASR, LLaVA for image captioning, and Qwen for reranking.
    When the model response includes a timestamp, click it to jump to that time in the video.
 

--- a/src/vss_engine/gradio_frontend.py
+++ b/src/vss_engine/gradio_frontend.py
@@ -294,7 +294,7 @@ class GradioApp:
                 outputs=[video, transcript_box, caption_box],
             )
             send.click(self.answer, inputs=[question, chatbot], outputs=chatbot)
-        demo.queue().launch(share=share)
+        demo.queue().launch(server_name="0.0.0.0", share=share)
 
 
 def main():


### PR DESCRIPTION
## Summary
- expose gradio interface on `0.0.0.0`
- update README with instructions on using the public interface

## Testing
- `python -m py_compile src/vss_engine/gradio_frontend.py`
- `bash -n run_local.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d4b4ff344832abe074dd3e1bc2e72