### PR TITLE
Add per-video RAG caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ The `/deploy/helm/` directory contains a `nvidia-blueprint-vss-2.3.0.tgz` file w
    Use `--share` to obtain a public Gradio link.
    This uses Whisper for ASR, LLaVA for image captioning, and Qwen for reranking.
    When the model response includes a timestamp, click it to jump to that time in the video.
+   The interface stores transcripts and frame captions in a per-video RAG database under `data/db`,
+   so repeated questions do not re-run inference over the same video.
 
 ## Known CVEs
 
@@ -186,5 +188,4 @@ VSS Engine 2.3.0 Source Code has the following known CVEs:
 	
 ## License
 The software and materials in this repository are governed by the [NVIDIA Software License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-software-license-agreement/) and the Product-Specific Terms for [NVIDIA AI Products](https://www.nvidia.com/en-us/agreements/enterprise-software/product-specific-terms-for-ai-products/); except for models which are governed by the [NVIDIA Community Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-community-models-license/).
-
 ADDITIONAL INFORMATION: [Llama 3.1 Community License Agreement](https://www.llama.com/llama3_1/license/) for Llama-3.1-70b-instruct; [Llama 3.2 Community License Agreement](https://www.llama.com/llama3_2/license/) for NVIDIA Retrieval QA Llama 3.2 1B Embedding v2 and NVIDIA Retrieval QA Llama 3.2 1B Reranking v2, Apache, Version 2.0 for https://github.com/google-research/big_vision/blob/main/LICENSE and Apache License, Version 2.0 for https://github.com/01-ai/Yi/blob/main/LICENSE. Built with Llama.

--- a/src/vss_engine/rag_db.py
+++ b/src/vss_engine/rag_db.py
@@ -1,0 +1,32 @@
+import os
+import pickle
+from typing import List, Dict, Any
+
+class RAGDatabase:
+    """Simple on-disk store for a single video's transcript and captions."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.data: Dict[str, Any] = {"transcript": "", "captions": []}
+        if os.path.exists(self.path):
+            with open(self.path, "rb") as f:
+                self.data = pickle.load(f)
+
+    def save(self) -> None:
+        os.makedirs(os.path.dirname(self.path) or ".", exist_ok=True)
+        with open(self.path, "wb") as f:
+            pickle.dump(self.data, f)
+
+    def add_transcript(self, transcript: str) -> None:
+        self.data["transcript"] = transcript
+        self.save()
+
+    def add_captions(self, captions: List[Dict[str, Any]]) -> None:
+        self.data["captions"] = captions
+        self.save()
+
+    def get_transcript(self) -> str:
+        return self.data.get("transcript", "")
+
+    def get_captions(self) -> List[Dict[str, Any]]:
+        return self.data.get("captions", [])


### PR DESCRIPTION
## Summary
- make `vss_engine` a package to fix imports
- implement per-video RAG database
- use the new cache in `gradio_frontend`
- document caching behaviour in README

## Testing
- `python -m py_compile src/vss_engine/pipeline.py src/vss_engine/rag_db.py src/vss_engine/gradio_frontend.py`

------
https://chatgpt.com/codex/tasks/task_e_686d6ecec4dc832a8916497fe6486bf9