### PR TITLE
Add progress tracking for realtime captioning

### DIFF
--- a/src/vss_engine/gradio_frontend.py
+++ b/src/vss_engine/gradio_frontend.py
@@ -161,7 +161,9 @@ class GradioApp:
         self.transcript = self.pipeline.transcribe(audio_bytes, source_id=vid_hash)
         progress((0, 0), desc="Processing frames")
         fps = 4.0
-        self.captions = self.pipeline.caption_realtime(str(saved_path), target_fps=fps, source_id=vid_hash)
+        self.captions = self.pipeline.caption_realtime(
+            str(saved_path), target_fps=fps, progress=progress, source_id=vid_hash
+        )
         self.fps = fps
         caption = self.captions[0]["caption"] if self.captions else ""
 


### PR DESCRIPTION
## Summary
- track progress of frame captioning and estimate remaining time
- show progress in Gradio frontend while uploading a video

## Testing
- `python -m py_compile src/vss_engine/gradio_frontend.py src/vss_engine/pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_686d8e9c0a8c832a8af7b18f927c75c3