### PR TITLE
Fix ffmpeg executable fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ The `/deploy/helm/` directory contains a `nvidia-blueprint-vss-2.3.0.tgz` file w
    ```bash
    # ffmpeg is required for audio and frame extraction
    sudo apt-get install ffmpeg  # or use brew on macOS
+   # If this is not available or fails to run, the Python package
+   # ``imageio-ffmpeg`` installed in the next step provides a
+   # portable ffmpeg binary.
    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
    pip3 install git+https://github.com/openai/whisper.git
 

--- a/src/vss_engine/gradio_frontend.py
+++ b/src/vss_engine/gradio_frontend.py
@@ -27,13 +27,25 @@ from vss_engine.pipeline import LocalPipeline  # noqa: E402
 
 
 def _ffmpeg() -> str:
-    """Return path to ffmpeg executable with a fallback."""
+    """Return path to a working ffmpeg executable with a fallback."""
     path = shutil.which("ffmpeg")
     if path:
-        return path
+        try:
+            subprocess.run(
+                [path, "-version"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            return path
+        except Exception:
+            pass
     if imageio_ffmpeg is not None:
         return imageio_ffmpeg.get_ffmpeg_exe()
-    raise RuntimeError("ffmpeg is required but not installed")
+    raise RuntimeError(
+        "ffmpeg is required but was not found. Install it or install the"
+        " imageio-ffmpeg Python package."
+    )
 
 def extract_audio_bytes(video_path: str | os.PathLike) -> bytes | None:
     """Return raw 16 kHz mono PCM audio from a video without writing to disk."""


### PR DESCRIPTION
## Summary
- ensure `_ffmpeg()` verifies the system ffmpeg is runnable
- describe imageio-ffmpeg fallback in README

## Testing
- `python3 -m py_compile src/vss_engine/gradio_frontend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687009ed4268832a91e7bdd811902c8c