### PR TITLE
Add AI Workbench pipeline compose and telemetry

### DIFF
--- a/.aiw.yml
+++ b/.aiw.yml
@@ -1,6 +1,6 @@
 version: 1
-docker_compose_file: docker-compose.yaml
-default_service: vss
+docker_compose_file: deploy/ai-workbench/docker-compose.yaml
+default_service: pipeline
 ui:
   type: gradio
   path: src/vss_engine/gradio_frontend.py

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,9 @@
+FROM nvcr.io/nvidia/pytorch:24.05-py3
+WORKDIR /app
+COPY requirements.txt ./
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src src
+COPY telemetry.py telemetry.py
+ENV OLLAMA_URL=http://localhost:11434
+CMD ["python", "src/vss_engine/gradio_frontend.py"]

--- a/Dockerfile.telemetry
+++ b/Dockerfile.telemetry
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY src/telemetry.py src/telemetry_server.py ./
+RUN pip install --no-cache-dir requests
+CMD ["python", "telemetry_server.py"]

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ The `/deploy/helm/` directory contains a `nvidia-blueprint-vss-2.3.0.tgz` file w
 To launch the demo quickly with [NVIDIA AI Workbench](https://developer.nvidia.com/ai-workbench),
 open this repository in Workbench. The provided
 `.workbench/workbench.yaml` specification installs the required dependencies and
-starts the Gradio interface automatically.
+starts the Gradio interface automatically. For a container-per-service setup,
+use the compose file under `deploy/ai-workbench` and launch the `vss-frontend`
+image from the Workbench UI.
 
 ### Local Setup with Ollama + Whisper
 

--- a/deploy/ai-workbench/README.md
+++ b/deploy/ai-workbench/README.md
@@ -1,0 +1,29 @@
+# AI Workbench Deployment
+
+This folder contains a simplified deployment scheme for running the Video Search and Summarization (VSS) demo in NVIDIA AI Workbench. Each service runs in its own container and all containers share a common Docker network.
+
+The frontend is built as a standalone container so it can be launched directly from the AI Workbench UI. It is not included in the compose file.
+
+## Services
+
+- **telemetry** – collects basic runtime metrics.
+- **ollama** – serves models used by the pipeline.
+- **pipeline** – runs the VSS processing pipeline.
+
+## Usage
+
+1. Ensure Docker is running and the `aiw-net` network exists:
+   ```bash
+   docker network create aiw-net || true
+   ```
+2. Start the backend services:
+   ```bash
+   docker compose -f deploy/ai-workbench/docker-compose.yaml up -d
+   ```
+3. Build the frontend container from the project root:
+   ```bash
+   docker build -f Dockerfile.frontend -t vss-frontend .
+   ```
+   Launch the container from the AI Workbench UI to access the Gradio interface.
+
+All services request access to GPU resources using the `NVIDIA_VISIBLE_DEVICES` environment variable and compose `deploy.resources` settings.

--- a/deploy/ai-workbench/docker-compose.yaml
+++ b/deploy/ai-workbench/docker-compose.yaml
@@ -1,0 +1,63 @@
+version: '3.8'
+
+services:
+  telemetry:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.telemetry
+    ports:
+      - "8000:8000"
+    networks:
+      - aiw-net
+
+  ollama:
+    image: ollama/ollama
+    command: serve
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    runtime: nvidia
+    networks:
+      - aiw-net
+
+  pipeline:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    command: python src/vss_engine/gradio_frontend.py
+    volumes:
+      - ../../data:/app/data
+    environment:
+      - OLLAMA_URL=http://ollama:11434
+      - TELEMETRY_URL=http://telemetry:8000
+      - NVIDIA_VISIBLE_DEVICES=all
+    depends_on:
+      - ollama
+      - telemetry
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    runtime: nvidia
+    networks:
+      - aiw-net
+
+volumes:
+  ollama_data:
+
+networks:
+  aiw-net:
+    external: true

--- a/src/telemetry.py
+++ b/src/telemetry.py
@@ -1,0 +1,27 @@
+import json
+import logging
+import time
+from typing import Any, Optional
+
+import requests
+
+
+class Telemetry:
+    """Simple telemetry helper for logging and optional HTTP reporting."""
+
+    def __init__(self, server_url: Optional[str] = None, log_file: str = "telemetry.log"):
+        self.server_url = server_url
+        self.logger = logging.getLogger("Telemetry")
+        self.logger.setLevel(logging.INFO)
+        handler = logging.FileHandler(log_file)
+        handler.setFormatter(logging.Formatter('%(message)s'))
+        self.logger.addHandler(handler)
+
+    def record(self, event: str, **kwargs: Any) -> None:
+        payload = {"event": event, "timestamp": time.time(), **kwargs}
+        self.logger.info(json.dumps(payload))
+        if self.server_url:
+            try:
+                requests.post(self.server_url, json=payload, timeout=1)
+            except Exception as exc:  # pragma: no cover - best effort
+                self.logger.debug("Failed to send telemetry: %s", exc)

--- a/src/telemetry_server.py
+++ b/src/telemetry_server.py
@@ -1,0 +1,19 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+class TelemetryHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        data = self.rfile.read(length).decode()
+        logging.info(data)
+        self.send_response(200)
+        self.end_headers()
+
+def run(host: str = '0.0.0.0', port: int = 8000) -> None:
+    server = HTTPServer((host, port), TelemetryHandler)
+    server.serve_forever()
+
+if __name__ == '__main__':
+    run()

--- a/src/vss_engine/gradio_frontend.py
+++ b/src/vss_engine/gradio_frontend.py
@@ -24,6 +24,7 @@ import gradio as gr
 # Allow importing as a package when executed from repository root
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from vss_engine.pipeline import LocalPipeline  # noqa: E402
+from telemetry import Telemetry  # noqa: E402
 
 
 def _ffmpeg() -> str:
@@ -125,8 +126,9 @@ def load_db(db_dir: Path, vid_hash: str) -> dict | None:
 
 
 class GradioApp:
-    def __init__(self, ollama_url: str):
-        self.pipeline = LocalPipeline(ollama_url, rag_db_dir="data/db")
+    def __init__(self, ollama_url: str, telemetry: Telemetry | None = None):
+        self.telemetry = telemetry or Telemetry(os.environ.get("TELEMETRY_URL"))
+        self.pipeline = LocalPipeline(ollama_url, rag_db_dir="data/db", telemetry=self.telemetry)
         self.transcript = ""
         self.frames: list[str] = []
         self.captions: list[dict] = []
@@ -312,7 +314,10 @@ class GradioApp:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ollama-url", default="http://localhost:11434")
+    parser.add_argument(
+        "--ollama-url",
+        default=os.environ.get("OLLAMA_URL", "http://localhost:11434"),
+    )
     parser.add_argument(
         "--share",
         action="store_true",
@@ -320,7 +325,8 @@ def main():
     )
     args = parser.parse_args()
     logging.basicConfig(level=os.environ.get("VSS_LOG_LEVEL", "INFO").upper())
-    app = GradioApp(args.ollama_url)
+    telem = Telemetry(os.environ.get("TELEMETRY_URL"))
+    app = GradioApp(args.ollama_url, telemetry=telem)
     app.launch(share=args.share)
 
 

--- a/src/vss_engine/pipeline.py
+++ b/src/vss_engine/pipeline.py
@@ -8,6 +8,7 @@ import gradio as gr
 import threading
 import queue
 from typing import Iterable, List, Dict, Optional, Union
+from telemetry import Telemetry
 from dataclasses import dataclass
 import cv2
 import numpy as np
@@ -40,9 +41,11 @@ class LocalPipeline:
         ollama_url: str = "http://localhost:11434",
         device: str | None = None,
         rag_db_dir: str = "data/db",
+        telemetry: Telemetry | None = None,
     ) -> None:
 
         self.logger = logging.getLogger(self.__class__.__name__)
+        self.telemetry = telemetry
         self.ollama_url = ollama_url.rstrip("/")
         if device is None:
             device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -66,10 +69,14 @@ class LocalPipeline:
         self.logger.debug(
             "Sending generate request to %s with model=%s", self.ollama_url, model
         )
+        if self.telemetry:
+            self.telemetry.record("generate_start", model=model)
         start = time.time()
         resp = requests.post(f"{self.ollama_url}/api/generate", json=payload)
         elapsed = time.time() - start
         self.logger.info("Model %s finished in %.2fs", model, elapsed)
+        if self.telemetry:
+            self.telemetry.record("generate_end", model=model, elapsed=elapsed)
         resp.raise_for_status()
         return resp
 
@@ -91,6 +98,8 @@ class LocalPipeline:
         self, audio: Union[str, bytes, np.ndarray, None], source_id: str | None = None
     ) -> str:
         """Transcribe audio from a path or raw bytes and cache the result."""
+        if self.telemetry:
+            self.telemetry.record("transcribe_start", source=source_id)
         self.logger.info(
             "Transcribing audio%s", f" for {source_id}" if source_id else ""
         )
@@ -118,6 +127,8 @@ class LocalPipeline:
         text = result.get("text", "")
         segments = result.get("segments", [])
         self.logger.info("Whisper transcription finished in %.2fs", elapsed)
+        if self.telemetry:
+            self.telemetry.record("transcribe_end", source=source_id, elapsed=elapsed)
         if source_id:
 
             db.add_transcript_segments(text, segments)
@@ -181,6 +192,8 @@ class LocalPipeline:
         Returns a list of ``FrameCaption`` dictionaries with ``frame``, ``time``
         and ``caption`` fields.
         """
+        if self.telemetry:
+            self.telemetry.record("caption_start", count=len(image_paths))
         self.logger.debug("Captioning %d frames", len(image_paths))
         if source_id:
 
@@ -251,6 +264,8 @@ class LocalPipeline:
         if source_id:
 
             db.add_captions(captions)
+        if self.telemetry:
+            self.telemetry.record("caption_end", count=len(image_paths))
 
         return captions
 
@@ -266,6 +281,8 @@ class LocalPipeline:
         reported via ``progress`` if provided. Returns a list of ``FrameCaption``
         dictionaries validated against the schema.
         """
+        if self.telemetry:
+            self.telemetry.record("realtime_caption_start", video=video_path)
         self.logger.info("Realtime captioning %s", video_path)
         if source_id:
 
@@ -346,6 +363,8 @@ class LocalPipeline:
         if source_id:
 
             db.add_captions(captions)
+        if self.telemetry:
+            self.telemetry.record("realtime_caption_end", frames=processed)
 
         return captions
 
@@ -370,6 +389,8 @@ class LocalPipeline:
         top_n: int = 3,
     ) -> tuple[str, list[str]]:
         """Generate an answer using RAG over the transcript and captions."""
+        if self.telemetry:
+            self.telemetry.record("answer_start")
         self.logger.info("Answering question: %s", question)
 
         if source_id:
@@ -421,7 +442,10 @@ class LocalPipeline:
                 "stream": False,
             }
         )
-        return resp.json().get("response", ""), context_docs
+        result = resp.json().get("response", "")
+        if self.telemetry:
+            self.telemetry.record("answer_end")
+        return result, context_docs
 
 
 if __name__ == "__main__":
@@ -438,7 +462,8 @@ if __name__ == "__main__":
     parser.add_argument("--image", default="frame.jpg", help="Path to image file")
     args = parser.parse_args()
 
-    pipe = LocalPipeline(args.ollama_url)
+    telem = Telemetry()
+    pipe = LocalPipeline(args.ollama_url, telemetry=telem)
     transcript = pipe.transcribe(args.audio)
     print("Transcript:", transcript)
 


### PR DESCRIPTION
## Summary
- add AI Workbench deployment folder with multi-container compose
- add Dockerfiles for frontend and telemetry server
- implement simple telemetry helper and server
- instrument pipeline and frontend with telemetry support
- update AI Workbench configuration and docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876bfdf828c832ab9f09ea7f1be306d