### PR TITLE
Add Gradio as managed web app

### DIFF
--- a/.project/spec.yaml
+++ b/.project/spec.yaml
@@ -51,6 +51,22 @@ environment:
                 proxy:
                     trim_prefix: false
                 url_command: jupyter lab list | head -n 2 | tail -n 1 | cut -f1 -d' ' | grep -v 'Currently'
+            - name: gradio
+              type: custom
+              class: webapp
+              start_command: python src/vss_engine/gradio_frontend.py
+              health_check_command: '[ $(curl -o /dev/null -s -w "%{http_code}" http://localhost:7860) == "200" ]'
+              stop_command: pkill -f gradio_frontend.py
+              user_msg: ""
+              logfile_path: ""
+              timeout_seconds: 60
+              icon_url: ""
+              webapp_options:
+                autolaunch: true
+                port: "7860"
+                proxy:
+                    trim_prefix: false
+                url_command: echo http://localhost:7860
         programming_languages:
             - python3
         icon_url: https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg

--- a/.workbench/workbench.yaml
+++ b/.workbench/workbench.yaml
@@ -10,6 +10,11 @@ packages:
     - torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
     - git+https://github.com/openai/whisper.git
     - -r requirements.txt
-run:
-  workdir: /workspace/vss-dev
-  cmd: python src/vss_engine/gradio_frontend.py
+applications:
+  - name: gradio
+    class: webapp
+    type: custom
+    run:
+      workdir: /workspace/vss-dev
+      cmd: python src/vss_engine/gradio_frontend.py
+      port: 7860

--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ The `/deploy/helm/` directory contains a `nvidia-blueprint-vss-2.3.0.tgz` file w
 
 To launch the demo quickly with [NVIDIA AI Workbench](https://developer.nvidia.com/ai-workbench),
 open this repository in Workbench. The provided
-`.workbench/workbench.yaml` specification installs the required dependencies and
-starts the Gradio interface automatically.
+`.workbench/workbench.yaml` specification installs the required dependencies.
+Gradio is configured as a managed application that can be started from the
+Applications section of the Workbench UI.
 
 ### Local Setup with Ollama + Whisper
 


### PR DESCRIPTION
## Summary
- configure Gradio as a managed Workbench application
- update AI Workbench instructions

## Testing
- `python -m py_compile src/vss_engine/gradio_frontend.py`


------
https://chatgpt.com/codex/tasks/task_e_6876c2c33908832aa853da015291282e