### PR TITLE
Update gradio startup to use python3

### DIFF
--- a/.project/spec.yaml
+++ b/.project/spec.yaml
@@ -54,7 +54,7 @@ environment:
             - name: gradio
               type: custom
               class: webapp
-              start_command: python src/vss_engine/gradio_frontend.py
+              start_command: python3 src/vss_engine/gradio_frontend.py
               health_check_command: '[ $(curl -o /dev/null -s -w "%{http_code}" http://localhost:7860) == "200" ]'
               stop_command: pkill -f gradio_frontend.py
               user_msg: ""

--- a/.workbench/workbench.yaml
+++ b/.workbench/workbench.yaml
@@ -16,5 +16,5 @@ applications:
     type: custom
     run:
       workdir: /workspace/vss-dev
-      cmd: python src/vss_engine/gradio_frontend.py
+      cmd: python3 src/vss_engine/gradio_frontend.py
       port: 7860

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -6,4 +6,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY src src
 COPY telemetry.py telemetry.py
 ENV OLLAMA_URL=http://localhost:11434
-CMD ["python", "src/vss_engine/gradio_frontend.py"]
+CMD ["python3", "src/vss_engine/gradio_frontend.py"]

--- a/Dockerfile.telemetry
+++ b/Dockerfile.telemetry
@@ -2,4 +2,4 @@ FROM python:3.10-slim
 WORKDIR /app
 COPY src/telemetry.py src/telemetry_server.py ./
 RUN pip install --no-cache-dir requests
-CMD ["python", "telemetry_server.py"]
+CMD ["python3", "telemetry_server.py"]

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Applications section of the Workbench UI.
 
 5. Launch the Gradio interface (or use `run_local.sh`):
    ```bash
-   python src/vss_engine/gradio_frontend.py
+    python3 src/vss_engine/gradio_frontend.py
    ```
    The interface now binds to `0.0.0.0` so it can be reached from other machines.
    Use `--share` to obtain a public Gradio link.

--- a/deploy/ai-workbench/docker-compose.yaml
+++ b/deploy/ai-workbench/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile
-    command: python src/vss_engine/gradio_frontend.py
+    command: python3 src/vss_engine/gradio_frontend.py
     volumes:
       - ../../data:/app/data
     environment:

--- a/run_local.sh
+++ b/run_local.sh
@@ -57,7 +57,7 @@ SHARE_ARG=""
 if [ "$PUBLIC" -eq 1 ]; then
   SHARE_ARG="--share"
 fi
-python src/vss_engine/gradio_frontend.py --ollama-url "http://localhost:${PORT}" $SHARE_ARG
+python3 src/vss_engine/gradio_frontend.py --ollama-url "http://localhost:${PORT}" $SHARE_ARG
 
 
 # Stop Ollama


### PR DESCRIPTION
## Summary
- switch all gradio launchers from `python` to `python3`
- update Dockerfiles and Compose config for python3
- adjust helper script and documentation

## Testing
- `python3 -m py_compile src/vss_engine/gradio_frontend.py`
- `pip install numpy`
- `pip install gradio`
- `pip install git+https://github.com/openai/whisper.git`
- `python3 src/vss_engine/gradio_frontend.py --help` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6876c5b3a210832aafa366673ae6b0b6