### PR TITLE
Refactor pipeline with modular ASR service

### DIFF
--- a/Dockerfile.asr
+++ b/Dockerfile.asr
@@ -1,0 +1,7 @@
+FROM nvcr.io/nvidia/pytorch:24.05-py3
+WORKDIR /app
+COPY requirements.asr.txt ./
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir -r requirements.asr.txt
+COPY src/asr_server.py .
+CMD ["uvicorn", "asr_server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -158,11 +158,21 @@ Applications section of the Workbench UI.
    ```
 
 
-   Or run the helper script:
-  ```bash
- ./run_local.sh [-p]
-  ```
- This helper installs the required PyTorch build and Whisper, starts Ollama on port 51234, pulls models, and launches the Gradio interface. Use `-p` to share the Gradio interface publicly.
+Or run the helper script:
+```bash
+./run_local.sh [-p]
+```
+This helper installs the required PyTorch build and Whisper, starts Ollama on port 51234, pulls models, and launches the Gradio interface. Use `-p` to share the Gradio interface publicly.
+
+### Modular Compose Setup
+
+For a more modular deployment where each model runs in its own container run:
+
+```bash
+docker compose -f docker-compose.modular.yml up
+```
+
+This compose file launches separate services for Ollama, a Whisper based ASR server, and the Gradio frontend. The frontend communicates with the ASR service using the `ASR_URL` environment variable.
 
 
 4. Pull models:

--- a/docker-compose.modular.yml
+++ b/docker-compose.modular.yml
@@ -1,0 +1,59 @@
+version: "3.8"
+services:
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    runtime: nvidia
+
+  asr:
+    build:
+      context: .
+      dockerfile: Dockerfile.asr
+    ports:
+      - "8000:8000"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    runtime: nvidia
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "7860:7860"
+    environment:
+      - OLLAMA_URL=http://ollama:11434
+      - ASR_URL=http://asr:8000
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      - ollama
+      - asr
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    runtime: nvidia
+
+volumes:
+  ollama_data:

--- a/requirements.asr.txt
+++ b/requirements.asr.txt
@@ -1,0 +1,6 @@
+torch
+torchvision
+torchaudio
+git+https://github.com/openai/whisper.git
+fastapi
+uvicorn

--- a/src/asr_server.py
+++ b/src/asr_server.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI, UploadFile, File
+import numpy as np
+import whisper
+import torch
+
+app = FastAPI()
+
+_device = "cuda" if torch.cuda.is_available() else "cpu"
+_model = whisper.load_model("small", device=_device)
+
+@app.post("/transcribe")
+async def transcribe(file: UploadFile = File(...)):
+    data = await file.read()
+    if not data:
+        return {"text": "", "segments": []}
+    audio = np.frombuffer(data, np.int16).astype(np.float32) / 32768.0
+    result = _model.transcribe(audio)
+    return {"text": result.get("text", ""), "segments": result.get("segments", [])}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/vss_engine/gradio_frontend.py
+++ b/src/vss_engine/gradio_frontend.py
@@ -128,7 +128,13 @@ def load_db(db_dir: Path, vid_hash: str) -> dict | None:
 class GradioApp:
     def __init__(self, ollama_url: str, telemetry: Telemetry | None = None):
         self.telemetry = telemetry or Telemetry(os.environ.get("TELEMETRY_URL"))
-        self.pipeline = LocalPipeline(ollama_url, rag_db_dir="data/db", telemetry=self.telemetry)
+        asr_url = os.environ.get("ASR_URL")
+        self.pipeline = LocalPipeline(
+            ollama_url,
+            rag_db_dir="data/db",
+            telemetry=self.telemetry,
+            asr_url=asr_url,
+        )
         self.transcript = ""
         self.frames: list[str] = []
         self.captions: list[dict] = []
@@ -319,6 +325,11 @@ def main():
         default=os.environ.get("OLLAMA_URL", "http://localhost:11434"),
     )
     parser.add_argument(
+        "--asr-url",
+        default=os.environ.get("ASR_URL"),
+        help="URL of the ASR service. If not provided, Whisper runs locally.",
+    )
+    parser.add_argument(
         "--share",
         action="store_true",
         help="Share the Gradio interface publicly",
@@ -326,6 +337,8 @@ def main():
     args = parser.parse_args()
     logging.basicConfig(level=os.environ.get("VSS_LOG_LEVEL", "INFO").upper())
     telem = Telemetry(os.environ.get("TELEMETRY_URL"))
+    if args.asr_url:
+        os.environ["ASR_URL"] = args.asr_url
     app = GradioApp(args.ollama_url, telemetry=telem)
     app.launch(share=args.share)
 


### PR DESCRIPTION
## Summary
- add an ASR microservice using Whisper
- compose file to run Ollama, ASR and Gradio separately
- allow pipeline to call remote ASR service
- expose ASR URL option in the Gradio frontend
- document modular compose setup

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c9a853d8832ab45b34b0fe64d93a