### PR TITLE
Add speculative decoding helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,10 @@ This compose file launches separate services for Ollama, a Whisper based ASR ser
 
 4. Pull models:
    ```bash
-   ollama pull llava-llama3:8b
+   # Large VLM
+   ollama pull llava:34b-v1.6
+   # Small draft model used for speculative decoding
+   ollama pull llava:7b-v1.6
    ```
 
 5. Launch the Gradio interface (or use `run_local.sh`):

--- a/run_local.sh
+++ b/run_local.sh
@@ -46,6 +46,7 @@ echo "Ollama running on port ${PORT}"
 # Pull required models
 
 ollama pull llava:34b-v1.6
+ollama pull llava:7b-v1.6
 ollama pull dengcao/Qwen3-Reranker-4B:Q4_K_M
 
 # Warm up llava model


### PR DESCRIPTION
## Summary
- pull a smaller model for speculative decoding
- mention the new model pull in docs
- add `draft_model` option to `LocalPipeline`
- generate captions using a draft model before refining with the larger model
- use speculative decoding in realtime captioning loop

## Testing
- `python -m py_compile src/vss_engine/pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6877cf18dfd8832aba9f9220037f1d6d