### PR TITLE
Modularize containers and remove whisper dependency

### DIFF
--- a/.workbench/workbench.yaml
+++ b/.workbench/workbench.yaml
@@ -8,7 +8,6 @@ packages:
     - ffmpeg
   pip:
     - torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-    - git+https://github.com/openai/whisper.git
     - -r requirements.txt
 applications:
   - name: gradio

--- a/Dockerfile.reranker
+++ b/Dockerfile.reranker
@@ -1,0 +1,5 @@
+FROM nvcr.io/nvidia/pytorch:24.05-py3
+WORKDIR /app
+RUN pip install --no-cache-dir fastapi uvicorn sentence-transformers
+COPY src/reranker_server.py .
+CMD ["uvicorn", "reranker_server:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/Dockerfile.spec
+++ b/Dockerfile.spec
@@ -1,0 +1,8 @@
+FROM python:3.10-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir fastapi uvicorn requests opencv-python-headless numpy
+COPY src/spec_server.py .
+ENV OLLAMA_URL=http://ollama:11434
+ENV DRAFT_MODEL=llava:7b-v1.6
+CMD ["uvicorn", "spec_server:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ open this repository in Workbench. The provided
 Gradio is configured as a managed application that can be started from the
 Applications section of the Workbench UI.
 
-### Local Setup with Ollama + Whisper
+### Local Setup with Ollama
 
 
-1. Install ffmpeg and PyTorch with CUDA 12.8 support, then Whisper from source:
+1. Install ffmpeg and PyTorch with CUDA 12.8 support:
    ```bash
    # ffmpeg is required for audio and frame extraction
    sudo apt-get install ffmpeg  # or use brew on macOS
@@ -137,8 +137,6 @@ Applications section of the Workbench UI.
    # ``imageio-ffmpeg`` installed in the next step provides a
    # portable ffmpeg binary.
    pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-   pip3 install git+https://github.com/openai/whisper.git
-
    ```
 
 2. Install Python dependencies:
@@ -162,7 +160,7 @@ Or run the helper script:
 ```bash
 ./run_local.sh [-p]
 ```
-This helper installs the required PyTorch build and Whisper, starts Ollama on port 51234, pulls models, and launches the Gradio interface. Use `-p` to share the Gradio interface publicly.
+This helper installs the required PyTorch build, starts Ollama on port 51234, pulls models, and launches the Gradio interface. Use `-p` to share the Gradio interface publicly.
 
 ### Modular Compose Setup
 
@@ -172,7 +170,7 @@ For a more modular deployment where each model runs in its own container run:
 docker compose -f docker-compose.modular.yml up
 ```
 
-This compose file launches separate services for Ollama, a Whisper based ASR server, and the Gradio frontend. The frontend communicates with the ASR service using the `ASR_URL` environment variable.
+This compose file launches separate services for Ollama, an ASR server, a reranker, a speculative captioning service, and the Gradio frontend. The frontend communicates with these services using the `ASR_URL`, `RERANKER_URL`, and `SPEC_URL` environment variables.
 
 
 4. Pull models:
@@ -189,7 +187,7 @@ This compose file launches separate services for Ollama, a Whisper based ASR ser
    ```
    The interface now binds to `0.0.0.0` so it can be reached from other machines.
    Use `--share` to obtain a public Gradio link.
-   This uses Whisper for ASR, LLaVA for image captioning, and a lightweight cross-encoder for reranking.
+   ASR, image captioning, and reranking now run in their own containers.
    When the model response includes a timestamp, click it to jump to that time in the video.
 
    The interface stores transcripts and frame captions in a per-video RAG database under `data/db`,

--- a/docker-compose.modular.yml
+++ b/docker-compose.modular.yml
@@ -32,6 +32,28 @@ services:
               capabilities: [gpu]
     runtime: nvidia
 
+  reranker:
+    build:
+      context: .
+      dockerfile: Dockerfile.reranker
+    ports:
+      - "8001:8001"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    runtime: nvidia
+
+  speculative:
+    build:
+      context: .
+      dockerfile: Dockerfile.spec
+    ports:
+      - "8002:8002"
+
   frontend:
     build:
       context: .
@@ -41,11 +63,15 @@ services:
     environment:
       - OLLAMA_URL=http://ollama:11434
       - ASR_URL=http://asr:8000
+      - RERANKER_URL=http://reranker:8001
+      - SPEC_URL=http://speculative:8002
     volumes:
       - ./data:/app/data
     depends_on:
       - ollama
       - asr
+      - reranker
+      - speculative
     deploy:
       resources:
         reservations:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,25 @@
 version: "3.8"
 services:
-  workspace:
-    build: .
-    image: aiw_project_image
-    container_name: aiw_project
-    volumes:
-      - .:/app
-    working_dir: /app
-    command: jupyter lab --allow-root --ip 0.0.0.0 --port 8888 --no-browser
+  reranker:
+    build:
+      context: .
+      dockerfile: Dockerfile.reranker
     ports:
-      - "8888:8888"
+      - "8001:8001"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    runtime: nvidia
+  speculative:
+    build:
+      context: .
+      dockerfile: Dockerfile.spec
+    ports:
+      - "8002:8002"
   ollama:
     image: ollama/ollama
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ requests
 torch
 torchvision
 torchaudio
-git+https://github.com/openai/whisper.git
 gradio
 moviepy
 opencv-python

--- a/run_local.sh
+++ b/run_local.sh
@@ -19,9 +19,8 @@ while getopts "p" opt; do
 done
 shift $((OPTIND - 1))
 
-# Install PyTorch for GPUs using CUDA 12.8 and Whisper from source
+# Install PyTorch for GPUs using CUDA 12.8
 pip3 install -q torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-pip3 install -q git+https://github.com/openai/whisper.git
 pip3 install -q sentence-transformers
 
 

--- a/src/reranker_server.py
+++ b/src/reranker_server.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sentence_transformers import CrossEncoder
+import torch
+
+app = FastAPI()
+_device = "cuda" if torch.cuda.is_available() else "cpu"
+_model = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2", device=_device)
+
+class RerankRequest(BaseModel):
+    query: str
+    docs: list[str]
+
+@app.post("/rerank")
+def rerank(req: RerankRequest):
+    if not req.docs:
+        return {"results": []}
+    pairs = [(req.query, doc) for doc in req.docs]
+    scores = _model.predict(pairs)
+    results = [
+        {"doc": doc, "score": float(score)} for doc, score in zip(req.docs, scores)
+    ]
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return {"results": results}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/src/spec_server.py
+++ b/src/spec_server.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI, UploadFile, File, Form
+import requests
+import base64
+import os
+
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://ollama:11434")
+DRAFT_MODEL = os.environ.get("DRAFT_MODEL", "llava:7b-v1.6")
+
+app = FastAPI()
+
+
+def _ollama_generate(payload: dict) -> dict:
+    resp = requests.post(f"{OLLAMA_URL}/api/generate", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def caption_image(image_bytes: bytes, context: str = "") -> str:
+    img_b64 = base64.b64encode(image_bytes).decode()
+    draft_payload = {
+        "model": DRAFT_MODEL,
+        "prompt": "Describe the frame in detail.",
+        "images": [img_b64],
+        "stream": False,
+    }
+    draft = _ollama_generate(draft_payload).get("response", "")
+    prompt = (
+        "You are a vision-language model refining a draft caption from a smaller model.\n"
+        f"Draft: {draft}\n"
+        f"Previous captions: {context}\n"
+        "Provide a final detailed caption for the current frame."
+    )
+    final_payload = {
+        "model": "llava:34b-v1.6",
+        "prompt": prompt,
+        "images": [img_b64],
+        "stream": False,
+    }
+    return _ollama_generate(final_payload).get("response", "")
+
+
+@app.post("/caption")
+async def caption(file: UploadFile = File(...), context: str = Form("")):
+    data = await file.read()
+    if not data:
+        return {"caption": ""}
+    cap = caption_image(data, context)
+    return {"caption": cap}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8002)

--- a/src/vss_engine/gradio_frontend.py
+++ b/src/vss_engine/gradio_frontend.py
@@ -129,11 +129,15 @@ class GradioApp:
     def __init__(self, ollama_url: str, telemetry: Telemetry | None = None):
         self.telemetry = telemetry or Telemetry(os.environ.get("TELEMETRY_URL"))
         asr_url = os.environ.get("ASR_URL")
+        reranker_url = os.environ.get("RERANKER_URL")
+        spec_url = os.environ.get("SPEC_URL")
         self.pipeline = LocalPipeline(
             ollama_url,
             rag_db_dir="data/db",
             telemetry=self.telemetry,
             asr_url=asr_url,
+            reranker_url=reranker_url,
+            spec_url=spec_url,
         )
         self.transcript = ""
         self.frames: list[str] = []


### PR DESCRIPTION
## Summary
- remove Whisper dependency from the frontend requirements
- add services for reranking and speculative decoding
- support remote ASR, reranker and speculative captioner in pipeline
- update compose files for new containers
- document new workflow and update helper scripts

## Testing
- `python3 -m py_compile src/vss_engine/pipeline.py src/vss_engine/gradio_frontend.py src/asr_server.py src/reranker_server.py src/spec_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6878254bebe0832a83578177724e317c