### PR TITLE
Use PyTorch 2.7 for reranker container

### DIFF
--- a/Dockerfile.reranker
+++ b/Dockerfile.reranker
@@ -1,4 +1,9 @@
-FROM nvcr.io/nvidia/pytorch:24.05-py3
+# Use a container image that ships with PyTorch 2.7 to satisfy the
+# requirement that the reranker runs on PyTorch 2.7.x. The official
+# PyTorch images from Docker Hub provide tagged releases with the
+# desired framework version. We rely on the CUDA-enabled runtime
+# variant so GPU acceleration remains available when deployed.
+FROM pytorch/pytorch:2.7.1-cuda12.6-cudnn9-runtime
 WORKDIR /app
 RUN pip install --no-cache-dir fastapi uvicorn sentence-transformers
 COPY src/reranker_server.py .


### PR DESCRIPTION
## Summary
- update `Dockerfile.reranker` to use the official PyTorch 2.7 image

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6878292f5600832a9130a2dde933dfa5