### PR TITLE
Integrate legacy UI assets

### DIFF
--- a/docker-compose.modular.yml
+++ b/docker-compose.modular.yml
@@ -23,6 +23,8 @@ services:
       dockerfile: Dockerfile.asr
     ports:
       - "8000:8000"
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
     deploy:
       resources:
         reservations:
@@ -38,6 +40,8 @@ services:
       dockerfile: Dockerfile.reranker
     ports:
       - "8001:8001"
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
     deploy:
       resources:
         reservations:
@@ -53,6 +57,8 @@ services:
       dockerfile: Dockerfile.spec
     ports:
       - "8002:8002"
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
 
   frontend:
     build:
@@ -65,6 +71,7 @@ services:
       - ASR_URL=http://asr:8000
       - RERANKER_URL=http://reranker:8001
       - SPEC_URL=http://speculative:8002
+      - NVIDIA_VISIBLE_DEVICES=all
     volumes:
       - ./data:/app/data
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
       dockerfile: Dockerfile.reranker
     ports:
       - "8001:8001"
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
     deploy:
       resources:
         reservations:
@@ -20,6 +22,8 @@ services:
       dockerfile: Dockerfile.spec
     ports:
       - "8002:8002"
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
   ollama:
     image: ollama/ollama
     ports:

--- a/src/vss_engine/gradio_frontend.py
+++ b/src/vss_engine/gradio_frontend.py
@@ -19,6 +19,9 @@ import numpy as np
 from pathlib import Path
 import sys
 
+# Assets from legacy UI
+LEGACY_ASSETS = Path(__file__).resolve().parent / "../vss-engine/src/client/assets"
+
 import gradio as gr
 
 # Allow importing as a package when executed from repository root
@@ -148,6 +151,16 @@ class GradioApp:
         self.db_dir = Path("data/db")
         self.video_dir.mkdir(parents=True, exist_ok=True)
         self.db_dir.mkdir(parents=True, exist_ok=True)
+
+        # Legacy UI assets
+        theme_json = LEGACY_ASSETS / "kaizen-theme.json"
+        css_file = LEGACY_ASSETS / "kaizen-theme.css"
+        app_bar_file = LEGACY_ASSETS / "app_bar.html"
+        self.theme = None
+        if theme_json.exists():
+            self.theme = gr.themes.Default().load(str(theme_json))
+        self.css = css_file.read_text() if css_file.exists() else ""
+        self.app_bar = app_bar_file.read_text() if app_bar_file.exists() else ""
 
     def _list_videos(self) -> list[str]:
         vids = []
@@ -286,7 +299,9 @@ class GradioApp:
         return history, "\n".join(context_docs)
 
     def launch(self, share: bool = False):
-        with gr.Blocks() as demo:
+        with gr.Blocks(theme=self.theme, css=self.css) as demo:
+            if self.app_bar:
+                gr.HTML(self.app_bar)
             video = gr.Video(label="Video", elem_id="video")
             url = gr.Textbox(label="Stream URL")
             capture_btn = gr.Button("Capture Stream")


### PR DESCRIPTION
## Summary
- style the Gradio frontend using assets from the previous demo UI
- allow all model containers to share the GPU by setting `NVIDIA_VISIBLE_DEVICES` in docker compose files

## Testing
- `python -m py_compile src/vss_engine/gradio_frontend.py`
- `python - <<'PY'
import yaml
yaml.safe_load(open('docker-compose.modular.yml'))
yaml.safe_load(open('docker-compose.yaml'))
print('OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68782b14692c832a8c5e657dfd9fb9bd