### PR TITLE
Fix spec container setup and compose GPU config

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Applications section of the Workbench UI.
 
    Or use Docker Compose:
    ```bash
+   # GPU-enabled compose file
    docker-compose up -d
    ```
 

--- a/docker-compose.modular.yml
+++ b/docker-compose.modular.yml
@@ -13,7 +13,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: all
+              device_ids: ["0"]
               capabilities: [gpu]
     runtime: nvidia
 
@@ -30,7 +30,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: all
+              device_ids: ["0"]
               capabilities: [gpu]
     runtime: nvidia
 
@@ -47,7 +47,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: all
+              device_ids: ["0"]
               capabilities: [gpu]
     runtime: nvidia
 
@@ -59,6 +59,14 @@ services:
       - "8002:8002"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    runtime: nvidia
 
   frontend:
     build:
@@ -84,7 +92,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: all
+              device_ids: ["0"]
               capabilities: [gpu]
     runtime: nvidia
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: all
+              device_ids: ["0"]
               capabilities: [gpu]
     runtime: nvidia
   speculative:
@@ -24,6 +24,14 @@ services:
       - "8002:8002"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    runtime: nvidia
   ollama:
     image: ollama/ollama
     ports:
@@ -37,7 +45,7 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: all
+              device_ids: ["0"]
               capabilities: [gpu]
     runtime: nvidia
 volumes:


### PR DESCRIPTION
## Summary
- configure GPU device IDs for reranker, speculative, and ollama services
- ensure modular compose uses GPU IDs for all services
- note GPU compose file in README

## Testing
- `python -m py_compile src/spec_server.py`

------
https://chatgpt.com/codex/tasks/task_e_687a6061bae0832abfc12debbdbe0e54