### PR TITLE
Fix reranker Docker build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:24.05-py3
+FROM --platform=linux/amd64 nvcr.io/nvidia/pytorch:24.05-py3
 WORKDIR /app
 COPY requirements.txt .
 RUN apt-get update && apt-get install -y ffmpeg libgl1 libglib2.0-0 \

--- a/Dockerfile.asr
+++ b/Dockerfile.asr
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:24.05-py3
+FROM --platform=linux/amd64 nvcr.io/nvidia/pytorch:24.05-py3
 WORKDIR /app
 COPY requirements.asr.txt ./
 RUN apt-get update && apt-get install -y ffmpeg libgl1 libglib2.0-0 && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:24.05-py3
+FROM --platform=linux/amd64 nvcr.io/nvidia/pytorch:24.05-py3
 WORKDIR /app
 COPY requirements.txt ./
 RUN apt-get update && apt-get install -y ffmpeg libgl1 libglib2.0-0 && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.reranker
+++ b/Dockerfile.reranker
@@ -3,7 +3,7 @@
 # PyTorch images from Docker Hub provide tagged releases with the
 # desired framework version. We rely on the CUDA-enabled runtime
 # variant so GPU acceleration remains available when deployed.
-FROM pytorch/pytorch:2.7.1-cuda12.6-cudnn9-runtime
+FROM --platform=linux/amd64 pytorch/pytorch:2.7.1-cuda12.6-cudnn9-runtime
 WORKDIR /app
 RUN pip install --no-cache-dir fastapi uvicorn sentence-transformers
 COPY src/reranker_server.py .

--- a/Dockerfile.spec
+++ b/Dockerfile.spec
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM --platform=linux/amd64 python:3.10-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y ffmpeg libgl1 libglib2.0-0 && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir fastapi uvicorn requests opencv-python-headless numpy

--- a/Dockerfile.telemetry
+++ b/Dockerfile.telemetry
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM --platform=linux/amd64 python:3.10-slim
 WORKDIR /app
 COPY src/telemetry.py src/telemetry_server.py ./
 RUN pip install --no-cache-dir requests


### PR DESCRIPTION
## Summary
- pin to linux/amd64 platform for all Dockerfiles to avoid exec format errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a62e26960832a8d031b5f3d8a9340